### PR TITLE
質問作成（内部ロジック）の作成

### DIFF
--- a/lib/models/entities/question.dart
+++ b/lib/models/entities/question.dart
@@ -47,6 +47,33 @@ class Question {
         updatedAt: ds['updated_at'].toDate());
   }
 
+  /// 新たに質問オブジェクトを作成するためのFactory
+  /// Firestoreには登録されないので別で登録処理を実行すること。
+  static Question newQuestion(FirebaseFirestore store, {
+    required String title,
+    required String text,
+    required String userId,
+    required double latitude,
+    required double longitude,
+  }) {
+    final userRef = store.collection("users").doc(userId).withUserConverter();
+    final now = DateTime.now();
+    return Question(
+      id: "",
+      title: title,
+      text: text,
+      address: null,
+      location: LocationPoint(
+        latitude: latitude,
+        longitude: longitude
+      ),
+      user: userRef,
+      userId: userId,
+      createdAt: DateTime.now(),
+      updatedAt: now
+    );
+  }
+
   Map<String, dynamic> toMap() {
     final geo = GeoFirePoint(this.location.latitude, this.location.longitude);
     return {

--- a/lib/models/entities/question.dart
+++ b/lib/models/entities/question.dart
@@ -49,7 +49,8 @@ class Question {
 
   /// 新たに質問オブジェクトを作成するためのFactory
   /// Firestoreには登録されないので別で登録処理を実行すること。
-  static Question newQuestion(FirebaseFirestore store, {
+  static Question newQuestion(
+    FirebaseFirestore store, {
     required String title,
     required String text,
     required String userId,
@@ -59,19 +60,15 @@ class Question {
     final userRef = store.collection("users").doc(userId).withUserConverter();
     final now = DateTime.now();
     return Question(
-      id: "",
-      title: title,
-      text: text,
-      address: null,
-      location: LocationPoint(
-        latitude: latitude,
-        longitude: longitude
-      ),
-      user: userRef,
-      userId: userId,
-      createdAt: DateTime.now(),
-      updatedAt: now
-    );
+        id: "",
+        title: title,
+        text: text,
+        address: null,
+        location: LocationPoint(latitude: latitude, longitude: longitude),
+        user: userRef,
+        userId: userId,
+        createdAt: DateTime.now(),
+        updatedAt: now);
   }
 
   Map<String, dynamic> toMap() {

--- a/lib/models/repositories/question_repository.dart
+++ b/lib/models/repositories/question_repository.dart
@@ -1,0 +1,20 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qomalin_app/models/entities/question.dart';
+import 'package:qomalin_app/providers/firestore.dart';
+
+abstract class QuestionRepository {
+  Future<Question?> create(Question question);
+}
+
+class FirebaseQuestionRepository extends QuestionRepository{
+  Reader reader;
+  FirebaseQuestionRepository(this.reader);
+  @override
+  Future<Question?> create(Question question) async {
+    final addResult = await reader(FirestoreProviders.questionCollectionRefProvider())
+      .add(question);
+    final res = await addResult.get();
+    return res.data();
+
+  }
+}

--- a/lib/models/repositories/question_repository.dart
+++ b/lib/models/repositories/question_repository.dart
@@ -6,15 +6,15 @@ abstract class QuestionRepository {
   Future<Question?> create(Question question);
 }
 
-class FirebaseQuestionRepository extends QuestionRepository{
+class FirebaseQuestionRepository extends QuestionRepository {
   Reader reader;
   FirebaseQuestionRepository(this.reader);
   @override
   Future<Question?> create(Question question) async {
-    final addResult = await reader(FirestoreProviders.questionCollectionRefProvider())
-      .add(question);
+    final addResult =
+        await reader(FirestoreProviders.questionCollectionRefProvider())
+            .add(question);
     final res = await addResult.get();
     return res.data();
-
   }
 }

--- a/lib/providers/questions.dart
+++ b/lib/providers/questions.dart
@@ -1,13 +1,20 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:qomalin_app/models/repositories/question_repository.dart';
 import 'package:qomalin_app/models/services/question_service.dart';
 
 final _questionServiceProvider =
     Provider((ref) => FirebaseQuestionService(ref.read));
+
+final _questionRepositoryProvider = Provider((ref) => FirebaseQuestionRepository(ref.read));
 
 class QuestionProviders {
   QuestionProviders._();
 
   static Provider<QuestionService> questionServiceProvider() {
     return _questionServiceProvider;
+  }
+
+  static Provider<QuestionRepository> questionRepositoryProvider() {
+    return _questionRepositoryProvider;
   }
 }

--- a/lib/providers/questions.dart
+++ b/lib/providers/questions.dart
@@ -5,7 +5,8 @@ import 'package:qomalin_app/models/services/question_service.dart';
 final _questionServiceProvider =
     Provider((ref) => FirebaseQuestionService(ref.read));
 
-final _questionRepositoryProvider = Provider((ref) => FirebaseQuestionRepository(ref.read));
+final _questionRepositoryProvider =
+    Provider((ref) => FirebaseQuestionRepository(ref.read));
 
 class QuestionProviders {
   QuestionProviders._();


### PR DESCRIPTION
永続化を抽象化するためのQuestionRepositoryとそれを実装するFirestoreQuestionRepositoryを作成しました。
QuestionエンティティにQuestionをいい感じに生成するためのstaticメソッドを追加しました。
ProviderにQuestionRepositoryを取得するためのProviderを実装しました。